### PR TITLE
fix: remove undefined groundPlane

### DIFF
--- a/src/chapter-01/04-materials-light-animation.html
+++ b/src/chapter-01/04-materials-light-animation.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html>
 
-<body>
-
 <head>
     <title>Example 01.04 - Materials, light and animation</title>
     <meta charset="UTF-8" />
@@ -14,6 +12,8 @@
     <script type="text/javascript" src="./js/01-04.js"></script>
     <link rel="stylesheet" href="../../css/default.css">
 </head>
+
+<body>
 
 <!-- Div which will hold the Output -->
 <div id="webgl-output"></div>

--- a/src/chapter-01/05-control-gui.html
+++ b/src/chapter-01/05-control-gui.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 
 <html>
-<body>
 
 <head>
     <title>Example 01.05 - Control gui</title>
@@ -16,6 +15,7 @@
     <link rel="stylesheet" href="../../css/default.css">
 </head>
 
+<body>
 <div id="webgl-output"></div>
 
 <!-- Javascript code that runs our Three.js examples -->

--- a/src/chapter-05/js/05-11.js
+++ b/src/chapter-05/js/05-11.js
@@ -19,7 +19,6 @@ function init() {
     // the start geometry and material. Used as the base for the settings in the control UI
     this.appliedMaterial = applyMeshNormalMaterial
     this.castShadow = true;
-    this.groundPlaneVisible = true;
 
     this.radius = 10;
     this.detail = 0;
@@ -74,7 +73,6 @@ function init() {
   }).onChange(controls.redraw)
 
   gui.add(controls, 'castShadow').onChange(function(e) {controls.mesh.castShadow = e})
-  gui.add(controls, 'groundPlaneVisible').onChange(function(e) {groundPlane.material.visible = e})
 
   // initialize the first redraw so everything gets initialized
   controls.redraw();

--- a/src/chapter-09/01-basic-animation.html
+++ b/src/chapter-09/01-basic-animation.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 
-<body>
 <head>
     <title>Example 09.01 - Simple animation</title>
     <meta charset="UTF-8" />
@@ -15,6 +14,8 @@
     <script type="text/javascript" src="../../libs/util/dat.gui.js"></script>
     <link rel="stylesheet" href="../../css/default.css">
 </head>
+
+<body>
 
 <!-- Div which will hold the Output -->
 <div id="webgl-output"></div>

--- a/src/chapter-09/02-selecting-objects.html
+++ b/src/chapter-09/02-selecting-objects.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 
-<body>
 <head>
     <title>Example 09.02 - Selecting objects</title>
     <meta charset="UTF-8" />
@@ -15,6 +14,8 @@
     <script type="text/javascript" src="../../libs/util/dat.gui.js"></script>
     <link rel="stylesheet" href="../../css/default.css">
 </head>
+
+<body>
 
 <!-- Div which will hold the Output -->
 <div id="webgl-output"></div>


### PR DESCRIPTION
This demo is using `addLargeGroundPlane`.
So remove unused `groundPlane`, otherwise will throw

> Uncaught ReferenceError: groundPlane is not defined

if user toggle it.